### PR TITLE
PayPal MVP: create/capture routes, Resend email, thank-you page, Pay button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@paypal/react-paypal-js": "^8.8.3",
         "next": "15.4.6",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "resend": "^6.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5312,6 +5313,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.0.1.tgz",
+      "integrity": "sha512-xNZ0gKAOqQcH83lXsqNOwBbpKROnsZpQr9mXRdG6hrHTF9G9Il2pkoTRtq7rJzXMvCZX+I79oahsbSeaYOWRFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@paypal/react-paypal-js": "^8.8.3",
     "next": "15.4.6",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "resend": "^6.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/dev/test-email/route.ts
+++ b/src/app/api/dev/test-email/route.ts
@@ -1,0 +1,36 @@
+// app/api/dev/test-email/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  const auth = req.headers.get('x-test-key');
+  if (!auth || auth !== process.env.RESEND_TEST_KEY) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+  }
+
+  const from = process.env.EMAIL_FROM!;
+  const to = process.env.ORDER_TO_EMAIL!;
+  const key = process.env.RESEND_API_KEY!;
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from,
+        to,
+        subject: 'Kami Kulture – Resend debug',
+        text: `Debug test at ${new Date().toISOString()}`,
+      }),
+      cache: 'no-store',
+    });
+
+    const body = await res.json();
+    return NextResponse.json({ ok: res.ok, status: res.status, body, from, to }, { status: res.status });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: String(e?.message ?? e) }, { status: 500 });
+  }
+}

--- a/src/app/api/dev/test-email/route.ts
+++ b/src/app/api/dev/test-email/route.ts
@@ -1,4 +1,3 @@
-// app/api/dev/test-email/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
@@ -9,9 +8,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
   }
 
-  const from = process.env.EMAIL_FROM!;
-  const to = process.env.ORDER_TO_EMAIL!;
-  const key = process.env.RESEND_API_KEY!;
+  const from = process.env.EMAIL_FROM ?? '';
+  const to = process.env.ORDER_TO_EMAIL ?? '';
+  const key = process.env.RESEND_API_KEY ?? '';
+
   try {
     const res = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -28,9 +28,10 @@ export async function POST(req: NextRequest) {
       cache: 'no-store',
     });
 
-    const body = await res.json();
-    return NextResponse.json({ ok: res.ok, status: res.status, body, from, to }, { status: res.status });
-  } catch (e: any) {
-    return NextResponse.json({ ok: false, error: String(e?.message ?? e) }, { status: 500 });
+    const body: unknown = await res.json();
+    return NextResponse.json({ ok: res.ok, status: res.status, body }, { status: res.status });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
 }

--- a/src/app/api/paypal/capture-order/route.ts
+++ b/src/app/api/paypal/capture-order/route.ts
@@ -1,16 +1,29 @@
-import { NextRequest, NextResponse } from "next/server";
-import { capturePaypalOrderServer } from "@/lib/paypal";
+// app/api/paypal/capture-order/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { captureOrder } from '@/lib/paypal';
+import { emailOrderJSON } from '@/lib/email';
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   try {
-    const { orderID } = await req.json();
-    if (!orderID) {
-      return NextResponse.json({ error: "Missing orderID" }, { status: 400 });
-    }
-    const result = await capturePaypalOrderServer(orderID);
-    return NextResponse.json({ ok: true, result });
-  } catch (e) {
-    const message = e instanceof Error ? e.message : "error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    const body = (await req.json()) as unknown;
+    const orderID =
+      typeof body === 'object' && body !== null && typeof (body as any).orderID === 'string'
+        ? (body as any).orderID
+        : '';
+
+    if (!orderID) return NextResponse.json({ error: 'INVALID_ORDER_ID' }, { status: 400 });
+
+    const capture = await captureOrder(orderID);
+
+    console.log('PAYPAL_CAPTURE', JSON.stringify(capture));
+    void emailOrderJSON(`Kami Kulture Order ${orderID}`, capture);
+
+    return NextResponse.json({ ok: true, orderID, capture }, { status: 200 });
+  } catch (err) {
+    console.error('/api/paypal/capture-order', err);
+    return NextResponse.json({ error: 'CAPTURE_FAILED' }, { status: 500 });
   }
 }
+

--- a/src/app/api/paypal/capture-order/route.ts
+++ b/src/app/api/paypal/capture-order/route.ts
@@ -1,18 +1,26 @@
-// app/api/paypal/capture-order/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { captureOrder } from '@/lib/paypal';
 import { emailOrderJSON } from '@/lib/email';
 
 export const runtime = 'nodejs';
 
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+async function getOrderID(req: NextRequest): Promise<string> {
+  try {
+    const raw: unknown = await req.json();
+    if (isRecord(raw) && typeof raw['orderID'] === 'string') return raw['orderID'];
+    return '';
+  } catch {
+    return '';
+  }
+}
+
 export async function POST(req: NextRequest) {
   try {
-    const body = (await req.json()) as unknown;
-    const orderID =
-      typeof body === 'object' && body !== null && typeof (body as any).orderID === 'string'
-        ? (body as any).orderID
-        : '';
-
+    const orderID = await getOrderID(req);
     if (!orderID) return NextResponse.json({ error: 'INVALID_ORDER_ID' }, { status: 400 });
 
     const capture = await captureOrder(orderID);
@@ -21,9 +29,9 @@ export async function POST(req: NextRequest) {
     void emailOrderJSON(`Kami Kulture Order ${orderID}`, capture);
 
     return NextResponse.json({ ok: true, orderID, capture }, { status: 200 });
-  } catch (err) {
-    console.error('/api/paypal/capture-order', err);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('/api/paypal/capture-order', message);
     return NextResponse.json({ error: 'CAPTURE_FAILED' }, { status: 500 });
   }
 }
-

--- a/src/app/api/paypal/capture-order/route.ts
+++ b/src/app/api/paypal/capture-order/route.ts
@@ -1,3 +1,4 @@
+// app/api/paypal/capture-order/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { captureOrder } from '@/lib/paypal';
 import { emailOrderJSON } from '@/lib/email';
@@ -8,25 +9,26 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null;
 }
 
-async function getOrderID(req: NextRequest): Promise<string> {
-  try {
-    const raw: unknown = await req.json();
-    if (isRecord(raw) && typeof raw['orderID'] === 'string') return raw['orderID'];
-    return '';
-  } catch {
-    return '';
-  }
-}
-
 export async function POST(req: NextRequest) {
   try {
-    const orderID = await getOrderID(req);
+    const raw = await req.json();
+    const orderID = isRecord(raw) && typeof raw.orderID === 'string' ? raw.orderID : '';
+    const emailOverride = isRecord(raw) && typeof raw.emailOverride === 'string' ? raw.emailOverride : null;
     if (!orderID) return NextResponse.json({ error: 'INVALID_ORDER_ID' }, { status: 400 });
 
     const capture = await captureOrder(orderID);
-
     console.log('PAYPAL_CAPTURE', JSON.stringify(capture));
-    void emailOrderJSON(`Kami Kulture Order ${orderID}`, capture);
+
+    // prefer explicit email in sandbox; payer email is fake there
+    const toEmail =
+      emailOverride ||
+      capture?.payer?.email_address ||
+      capture?.payment_source?.paypal?.email_address ||
+      process.env.ORDER_NOTIFY_EMAIL ||
+      'orders@kamikulture.com';
+
+    // IMPORTANT: await the email send so the function doesn’t exit early
+    await emailOrderJSON(`Kami Kulture Order ${orderID}`, capture, { to: toEmail });
 
     return NextResponse.json({ ok: true, orderID, capture }, { status: 200 });
   } catch (err: unknown) {

--- a/src/app/api/paypal/capture-order/route.ts
+++ b/src/app/api/paypal/capture-order/route.ts
@@ -1,51 +1,67 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { captureOrder } from '@/lib/paypal';
+import { captureOrder, showOrder } from '@/lib/paypal';
 import { emailOrderJSON } from '@/lib/email';
 
 export const runtime = 'nodejs';
 
 type PaypalCapture = {
+  status?: string;
   payer?: { email_address?: string };
   payment_source?: { paypal?: { email_address?: string } };
-  status?: string;
-} & Record<string, unknown>; // <- not `any`
+} & Record<string, unknown>;
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null;
 }
 
-function getPayerEmail(capture: unknown): string | null {
-  if (!isRecord(capture)) return null;
-  const c = capture as PaypalCapture;
-  return (
-    c.payer?.email_address ??
-    c.payment_source?.paypal?.email_address ??
-    null
-  );
+function getPayerEmail(c: PaypalCapture): string | null {
+  return c.payer?.email_address ?? c.payment_source?.paypal?.email_address ?? null;
 }
 
 export async function POST(req: NextRequest) {
   try {
-    const raw = await req.json();
-    const orderID = isRecord(raw) && typeof raw.orderID === 'string' ? raw.orderID : '';
-    const emailOverride = isRecord(raw) && typeof raw.emailOverride === 'string' ? raw.emailOverride : null;
-    if (!orderID) return NextResponse.json({ error: 'INVALID_ORDER_ID' }, { status: 400 });
+    const body = await req.json();
+    const orderID = isRecord(body) && typeof body.orderID === 'string' ? body.orderID : '';
+    const emailOverride = isRecord(body) && typeof body.emailOverride === 'string' ? body.emailOverride : null;
+    if (!orderID) return NextResponse.json({ ok: false, error: 'INVALID_ORDER_ID' }, { status: 400 });
 
-    const capture = (await captureOrder(orderID)) as unknown; // keep as unknown
-    console.log('PAYPAL_CAPTURE', JSON.stringify(capture));
+    let capture: PaypalCapture;
 
-    const toEmail =
-      emailOverride ||
-      getPayerEmail(capture) ||
-      process.env.ORDER_TO_EMAIL ||
-      'orders@kamikulture.com';
+    try {
+      capture = (await captureOrder(orderID)) as PaypalCapture;
+      console.log('PAYPAL_CAPTURE_OK', orderID, capture.status);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.includes('ORDER_ALREADY_CAPTURED')) {
+        console.warn('ORDER_ALREADY_CAPTURED — fetching order details instead');
+        capture = (await showOrder(orderID)) as PaypalCapture;
+      } else {
+        throw e;
+      }
+    }
 
-    await emailOrderJSON(`Kami Kulture Order ${orderID}`, capture, { to: toEmail });
+    // Try email, but don't block success/redirect on email failure
+    let emailSent = false;
+    try {
+      const to =
+        emailOverride ||
+        getPayerEmail(capture) ||
+        process.env.ORDER_TO_EMAIL ||
+        '';
+      if (to && process.env.EMAIL_FROM && process.env.RESEND_API_KEY) {
+        await emailOrderJSON(`Kami Kulture Order ${orderID}`, capture, { to });
+        emailSent = true;
+      } else {
+        console.warn('EMAIL_SKIPPED', { to });
+      }
+    } catch (err) {
+      console.error('EMAIL_SEND_ERROR', err);
+    }
 
-    return NextResponse.json({ ok: true, orderID }, { status: 200 });
+    return NextResponse.json({ ok: true, orderID, emailSent }, { status: 200 });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error('/api/paypal/capture-order', message);
-    return NextResponse.json({ error: 'CAPTURE_FAILED' }, { status: 500 });
+    return NextResponse.json({ ok: false, error: 'CAPTURE_FAILED' }, { status: 500 });
   }
 }

--- a/src/app/api/paypal/create-order/route.ts
+++ b/src/app/api/paypal/create-order/route.ts
@@ -1,23 +1,42 @@
-// app/api/paypal/create-order/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { createOrder } from '@/lib/paypal';
 
 export const runtime = 'nodejs';
 
+type CreateBody = { product: 'kami-tee'; qty?: number };
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+async function parseCreateBody(req: NextRequest): Promise<CreateBody> {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return { product: 'kami-tee', qty: 1 };
+  }
+  if (!isRecord(raw)) return { product: 'kami-tee', qty: 1 };
+
+  const product = raw['product'] === 'kami-tee' ? 'kami-tee' : 'kami-tee';
+  const qtyNum =
+    typeof raw['qty'] === 'number'
+      ? raw['qty']
+      : typeof raw['qty'] === 'string'
+      ? Number(raw['qty'])
+      : 1;
+
+  return { product, qty: Number.isFinite(qtyNum) && qtyNum > 0 ? qtyNum : 1 };
+}
+
 export async function POST(req: NextRequest) {
   try {
-    const body = (await req.json()) as unknown;
-    const { product, qty } = ((): { product: 'kami-tee'; qty: number } => {
-      if (typeof body === 'object' && body !== null && (body as any).product === 'kami-tee') {
-        const q = Number((body as any).qty ?? 1);
-        return { product: 'kami-tee', qty: Number.isFinite(q) && q > 0 ? q : 1 };
-      }
-      return { product: 'kami-tee', qty: 1 };
-    })();
-    const order = await createOrder(product, qty);
+    const { product, qty } = await parseCreateBody(req);
+    const order = await createOrder(product, qty ?? 1);
     return NextResponse.json({ id: order.id, status: order.status }, { status: 200 });
-  } catch (err) {
-    console.error('/api/paypal/create-order', err);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('/api/paypal/create-order', message);
     return NextResponse.json({ error: 'CREATE_FAILED' }, { status: 500 });
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 // src/app/page.tsx
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import PaySection from '@/components/PaySection';
 
 const LAUNCH_UTC = "2025-09-15T04:00:00Z";
 
@@ -70,7 +71,7 @@ export default function Home() {
             Notify me
           </button>
         </form>
-
+        <PaySection />
         <p className="mt-2 text-xs text-white/50">No spam. Unsubscribe anytime.</p>
 
         <div className="mt-8 flex gap-6 text-white/70">

--- a/src/app/product/kami-tee/page.tsx
+++ b/src/app/product/kami-tee/page.tsx
@@ -4,7 +4,7 @@ import { PayPalScriptProvider, PayPalButtons } from '@paypal/react-paypal-js';
 import type { ReactPayPalScriptOptions } from '@paypal/react-paypal-js';
 
 const options: ReactPayPalScriptOptions = {
-  clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID ?? 'AQZOPq6P2KwuDeAAWN2FDTytXuE7VkH8_MCfuvP8CyOTnS4UZSaC1pbk1y2I_8GCFa6qX-bVSktszrET',
+  clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID ?? '',
   currency: 'USD',
   intent: 'capture',
 };

--- a/src/app/product/kami-tee/page.tsx
+++ b/src/app/product/kami-tee/page.tsx
@@ -1,40 +1,51 @@
 'use client';
 
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { PayPalScriptProvider, PayPalButtons } from '@paypal/react-paypal-js';
 import type { ReactPayPalScriptOptions } from '@paypal/react-paypal-js';
 
 const options: ReactPayPalScriptOptions = {
-  clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID ?? '',
+  clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID || '',
   currency: 'USD',
   intent: 'capture',
 };
 
 export default function KamiTeePage() {
+  const [status, setStatus] = useState('');
+  const router = useRouter();
+
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
       <h1 className="text-3xl font-bold">Kami Tee</h1>
+
       <div className="mt-4">
         <PayPalScriptProvider options={options}>
           <PayPalButtons
             style={{ layout: 'vertical' }}
             createOrder={async () => {
+              setStatus('Creating order…');
               const r = await fetch('/api/paypal/create-order', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ product: 'kami-tee', qty: 1 }),
               });
-              const { id } = await r.json();
+              if (!r.ok) throw new Error('Create failed');
+              const { id } = (await r.json()) as { id: string };
+              setStatus('Opening PayPal…');
               return id;
             }}
-            onApprove={async (data) => {
+            onApprove={async (data: { orderID: string }) => {
               try {
                 setStatus('Capturing payment…');
+                // Server handles capture + email. No client capture to avoid 422.
                 const r = await fetch('/api/paypal/capture-order', {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify({
                     orderID: data.orderID,
-                    emailOverride: 'orders@kamikulture.com', // <-- real inbox for sandbox tests
+                    // use env-based recipient (ORDER_TO_EMAIL); uncomment to force an address while testing:
+                    // emailOverride: 'kamikulture99@gmail.com',
                   }),
                 });
                 const out = await r.json();
@@ -46,9 +57,15 @@ export default function KamiTeePage() {
                 setStatus('Payment error. Please try again.');
               }
             }}
+            onError={(err) => {
+              console.error(err);
+              setStatus('Payment error. Please try again.');
+            }}
           />
         </PayPalScriptProvider>
       </div>
+
+      {status && <p className="mt-3 text-sm text-neutral-700">{status}</p>}
     </main>
   );
 }

--- a/src/app/product/kami-tee/page.tsx
+++ b/src/app/product/kami-tee/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { PayPalScriptProvider, PayPalButtons } from '@paypal/react-paypal-js';
-import type { PayPalScriptOptions } from '@paypal/react-paypal-js';
+import type { ReactPayPalScriptOptions } from '@paypal/react-paypal-js';
 
-const options: PayPalScriptOptions = {
-  clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID ?? '', // must be a string
+const options: ReactPayPalScriptOptions = {
+  clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID ?? '',
   currency: 'USD',
   intent: 'capture',
 };
@@ -12,7 +12,7 @@ const options: PayPalScriptOptions = {
 export default function KamiTeePage() {
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
-      {/* ...product UI... */}
+      <h1 className="text-3xl font-bold">Kami Tee</h1>
       <div className="mt-4">
         <PayPalScriptProvider options={options}>
           <PayPalButtons

--- a/src/app/product/kami-tee/page.tsx
+++ b/src/app/product/kami-tee/page.tsx
@@ -4,7 +4,7 @@ import { PayPalScriptProvider, PayPalButtons } from '@paypal/react-paypal-js';
 import type { ReactPayPalScriptOptions } from '@paypal/react-paypal-js';
 
 const options: ReactPayPalScriptOptions = {
-  clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID ?? '',
+  clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID ?? 'AQZOPq6P2KwuDeAAWN2FDTytXuE7VkH8_MCfuvP8CyOTnS4UZSaC1pbk1y2I_8GCFa6qX-bVSktszrET',
   currency: 'USD',
   intent: 'capture',
 };

--- a/src/app/thank-you/page.tsx
+++ b/src/app/thank-you/page.tsx
@@ -1,0 +1,11 @@
+export default function ThankYou({ searchParams }: { searchParams: { orderID?: string } }) {
+    const id = searchParams.orderID ?? '';
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-16 text-center">
+        <h1 className="text-3xl font-bold">Thanks for your order!</h1>
+        {id && <p className="mt-3 text-sm text-neutral-600">Order ID: <code>{id}</code></p>}
+        <p className="mt-6">We’ve received your order and will process it shortly.</p>
+      </main>
+    );
+  }
+  

--- a/src/app/thank-you/page.tsx
+++ b/src/app/thank-you/page.tsx
@@ -1,11 +1,23 @@
-export default function ThankYou({ searchParams }: { searchParams: { orderID?: string } }) {
-    const id = searchParams.orderID ?? '';
-    return (
-      <main className="mx-auto max-w-2xl px-4 py-16 text-center">
-        <h1 className="text-3xl font-bold">Thanks for your order!</h1>
-        {id && <p className="mt-3 text-sm text-neutral-600">Order ID: <code>{id}</code></p>}
-        <p className="mt-6">We’ve received your order and will process it shortly.</p>
-      </main>
-    );
-  }
-  
+// /src/app/thank-you/page.tsx
+export default async function ThankYou({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const raw = sp?.orderID;
+  const orderID =
+    typeof raw === 'string' ? raw : Array.isArray(raw) ? raw[0] ?? '' : '';
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-16 text-center">
+      <h1 className="text-3xl font-bold">Thanks for your order!</h1>
+      {orderID && (
+        <p className="mt-3 text-sm text-neutral-600">
+          Order ID: <code>{orderID}</code>
+        </p>
+      )}
+      <p className="mt-6">We’ve received your order and will process it shortly.</p>
+    </main>
+  );
+}

--- a/src/components/PaySection.tsx
+++ b/src/components/PaySection.tsx
@@ -36,22 +36,21 @@ export default function PaySection() {
               return id;
             }}
             // onApprove in PaySection
-onApprove={async (data, actions) => {
-  setStatus('Capturing payment…');
-  await actions.order!.capture();
-  const r = await fetch('/api/paypal/capture-order', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      orderID: data.orderID,
-      emailOverride: 'orders@kamikulture.com', // real inbox for sandbox tests
-    }),
-  });
-  const out = await r.json();
-  if (!r.ok || !out.ok) throw new Error('Capture failed');
-  setStatus('Payment captured ✅');
-  router.push(`/thank-you?orderID=${encodeURIComponent(data.orderID)}`);
-}}
+            onApprove={async (data) => {
+              setStatus('Capturing payment…');
+              const r = await fetch('/api/paypal/capture-order', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  orderID: data.orderID,
+                  emailOverride: 'kamikulture99@gmail.com', // real inbox for sandbox tests
+                }),
+              });
+              const out = await r.json();
+              if (!r.ok || !out.ok) throw new Error(out.error || 'Capture failed');
+              router.push(`/thank-you?orderID=${encodeURIComponent(data.orderID)}`);
+            }}
+            
 
             onError={(err) => {
               console.error(err);

--- a/src/components/PaySection.tsx
+++ b/src/components/PaySection.tsx
@@ -35,18 +35,24 @@ export default function PaySection() {
               setStatus('Opening PayPal…');
               return id;
             }}
-            onApprove={async (data) => {
-              setStatus('Capturing payment…');
-              const r = await fetch('/api/paypal/capture-order', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ orderID: data.orderID }),
-              });
-              const out = await r.json();
-              if (!r.ok || !out.ok) throw new Error('Capture failed');
-              setStatus('Payment captured ✅');
-              router.push(`/thank-you?orderID=${encodeURIComponent(data.orderID)}`);
-            }}
+            // onApprove in PaySection
+onApprove={async (data, actions) => {
+  setStatus('Capturing payment…');
+  await actions.order!.capture();
+  const r = await fetch('/api/paypal/capture-order', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      orderID: data.orderID,
+      emailOverride: 'orders@kamikulture.com', // real inbox for sandbox tests
+    }),
+  });
+  const out = await r.json();
+  if (!r.ok || !out.ok) throw new Error('Capture failed');
+  setStatus('Payment captured ✅');
+  router.push(`/thank-you?orderID=${encodeURIComponent(data.orderID)}`);
+}}
+
             onError={(err) => {
               console.error(err);
               setStatus('Payment error. Please try again.');

--- a/src/components/PaySection.tsx
+++ b/src/components/PaySection.tsx
@@ -14,13 +14,13 @@ export default function PaySection() {
       <p className="text-sm text-neutral-600">US-only, PayPal checkout</p>
 
       <div className="mt-4">
-        <PayPalScriptProvider
-          options={{
-            'client-id': process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID!,
-            currency: 'USD',
-            intent: 'capture',
-          }}
-        >
+      <PayPalScriptProvider
+  options={{
+    clientId: process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID ?? '',
+    currency: 'USD',
+    intent: 'capture',
+  }}
+>
           <PayPalButtons
             style={{ layout: 'vertical' }}
             createOrder={async () => {

--- a/src/components/PaySection.tsx
+++ b/src/components/PaySection.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { PayPalScriptProvider, PayPalButtons } from '@paypal/react-paypal-js';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export default function PaySection() {
   const [status, setStatus] = useState('');
+  const router = useRouter();
 
   return (
     <section className="mt-10 rounded-lg border p-6">
@@ -23,26 +25,27 @@ export default function PaySection() {
             style={{ layout: 'vertical' }}
             createOrder={async () => {
               setStatus('Creating order…');
-              const res = await fetch('/api/paypal/create-order', {
+              const r = await fetch('/api/paypal/create-order', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ product: 'kami-tee', qty: 1 }),
               });
-              if (!res.ok) throw new Error('Create failed');
-              const data = (await res.json()) as { id: string };
+              if (!r.ok) throw new Error('Create failed');
+              const { id } = await r.json();
               setStatus('Opening PayPal…');
-              return data.id;
+              return id;
             }}
             onApprove={async (data) => {
               setStatus('Capturing payment…');
-              const res = await fetch('/api/paypal/capture-order', {
+              const r = await fetch('/api/paypal/capture-order', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ orderID: data.orderID }),
               });
-              const out = await res.json();
-              if (!res.ok || !out.ok) throw new Error('Capture failed');
-              setStatus('Payment captured ✅ Check your email & logs.');
+              const out = await r.json();
+              if (!r.ok || !out.ok) throw new Error('Capture failed');
+              setStatus('Payment captured ✅');
+              router.push(`/thank-you?orderID=${encodeURIComponent(data.orderID)}`);
             }}
             onError={(err) => {
               console.error(err);

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,3 +1,4 @@
+// lib/email.ts
 import 'server-only';
 import { Resend } from 'resend';
 
@@ -11,14 +12,19 @@ export async function emailOrderJSON(
   const to = opts?.to || process.env.ORDER_TO_EMAIL!;
   const from = process.env.EMAIL_FROM!;
 
-  const res = await resend.emails.send({
+  const { data, error } = await resend.emails.send({
     from,
     to,
     subject,
     text: JSON.stringify(json, null, 2),
-    html: opts?.html || `<pre>${JSON.stringify(json, null, 2)}</pre>`
+    html: opts?.html || `<pre>${JSON.stringify(json, null, 2)}</pre>`,
   });
 
-  console.log("EMAIL_SEND_OK", res?.id || res);
-  return res;
+  if (error) {
+    console.error('EMAIL_SEND_FAIL', error);
+    throw new Error(error.message || 'Resend send failed');
+  }
+
+  console.log('EMAIL_SEND_OK', data?.id);
+  return { id: data?.id };
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -7,13 +7,30 @@ function parseRecipients(v?: string): string | string[] {
   return list.length > 1 ? list : list[0];
 }
 
+function cleanFrom(v?: string): string {
+  // Trim + strip any leading/trailing single/double quotes
+  const raw = (v || '').trim().replace(/^['"]+|['"]+$/g, '');
+  // Normalize to either "Name <email@domain>" or "email@domain"
+  const m = raw.match(/^(.*)<\s*([^>]+)\s*>$/);
+  if (m) {
+    const name = m[1].trim();
+    const email = m[2].trim();
+    return name ? `${name} <${email}>` : email;
+  }
+  return raw;
+}
+
+function escapeHtml(s: string) {
+  return s.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]!));
+}
+
 export async function emailOrderJSON(
   subject: string,
   json: unknown,
   opts?: { to?: string | string[]; html?: string }
 ) {
   const to = opts?.to ?? parseRecipients(process.env.ORDER_TO_EMAIL);
-  const from = process.env.EMAIL_FROM!; // e.g. "Kami Kulture <orders@kamikulture.com>"
+  const from = cleanFrom(process.env.EMAIL_FROM) || 'orders@kamikulture.com'; // <- sanitized
 
   console.log('EMAIL_ENV_CHECK', {
     hasKey: !!process.env.RESEND_API_KEY,
@@ -29,10 +46,10 @@ export async function emailOrderJSON(
     },
     body: JSON.stringify({
       from,
-      to, // string or string[] both supported by Resend
+      to, // string or string[] both supported
       subject,
       text: JSON.stringify(json, null, 2),
-      html: opts?.html || `<pre>${JSON.stringify(json, null, 2)}</pre>`,
+      html: opts?.html || `<pre>${escapeHtml(JSON.stringify(json, null, 2))}</pre>`,
     }),
     cache: 'no-store',
   });

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,16 @@
+import 'server-only';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY!);
+
+export async function emailOrderJSON(subject: string, json: unknown) {
+  const to = process.env.ORDER_TO_EMAIL!;
+  const from = process.env.EMAIL_FROM!;
+  const res = await resend.emails.send({
+    from,
+    to,
+    subject,
+    text: JSON.stringify(json, null, 2),
+  });
+  return res;
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -3,14 +3,22 @@ import { Resend } from 'resend';
 
 const resend = new Resend(process.env.RESEND_API_KEY!);
 
-export async function emailOrderJSON(subject: string, json: unknown) {
-  const to = process.env.ORDER_TO_EMAIL!;
+export async function emailOrderJSON(
+  subject: string,
+  json: unknown,
+  opts?: { to?: string; html?: string }
+) {
+  const to = opts?.to || process.env.ORDER_TO_EMAIL!;
   const from = process.env.EMAIL_FROM!;
+
   const res = await resend.emails.send({
     from,
     to,
     subject,
     text: JSON.stringify(json, null, 2),
+    html: opts?.html || `<pre>${JSON.stringify(json, null, 2)}</pre>`
   });
+
+  console.log("EMAIL_SEND_OK", res?.id || res);
   return res;
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,30 +1,47 @@
 // lib/email.ts
 import 'server-only';
-import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY!);
+function parseRecipients(v?: string): string | string[] {
+  if (!v) return 'orders@kamikulture.com';
+  const list = v.split(',').map(s => s.trim()).filter(Boolean);
+  return list.length > 1 ? list : list[0];
+}
 
 export async function emailOrderJSON(
   subject: string,
   json: unknown,
-  opts?: { to?: string; html?: string }
+  opts?: { to?: string | string[]; html?: string }
 ) {
-  const to = opts?.to || process.env.ORDER_TO_EMAIL!;
-  const from = process.env.EMAIL_FROM!;
+  const to = opts?.to ?? parseRecipients(process.env.ORDER_TO_EMAIL);
+  const from = process.env.EMAIL_FROM!; // e.g. "Kami Kulture <orders@kamikulture.com>"
 
-  const { data, error } = await resend.emails.send({
+  console.log('EMAIL_ENV_CHECK', {
+    hasKey: !!process.env.RESEND_API_KEY,
     from,
     to,
-    subject,
-    text: JSON.stringify(json, null, 2),
-    html: opts?.html || `<pre>${JSON.stringify(json, null, 2)}</pre>`,
   });
 
-  if (error) {
-    console.error('EMAIL_SEND_FAIL', error);
-    throw new Error(error.message || 'Resend send failed');
-  }
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from,
+      to, // string or string[] both supported by Resend
+      subject,
+      text: JSON.stringify(json, null, 2),
+      html: opts?.html || `<pre>${JSON.stringify(json, null, 2)}</pre>`,
+    }),
+    cache: 'no-store',
+  });
 
-  console.log('EMAIL_SEND_OK', data?.id);
-  return { id: data?.id };
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    console.error('RESEND_RAW_FAIL', res.status, body);
+    return { ok: false, status: res.status, body };
+  }
+  console.log('RESEND_RAW_OK', body?.id || body);
+  return { ok: true, id: body?.id };
 }

--- a/src/lib/paypal.ts
+++ b/src/lib/paypal.ts
@@ -88,3 +88,20 @@ export async function captureOrder(orderID: string) {
   if (!res.ok) throw new Error(`PayPal capture error: ${res.status} ${await res.text()}`);
   return (await res.json()) as CaptureOrderResponse;
 }
+
+export async function showOrder(orderId: string) {
+  const base = process.env.PAYPAL_ENV === 'sandbox'
+    ? 'https://api.sandbox.paypal.com'
+    : 'https://api-m.paypal.com';
+
+  // reuse your existing getAccessToken() logic
+  const token = await getAccessToken();
+
+  const res = await fetch(`${base}/v2/checkout/orders/${orderId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(`Show order failed: ${res.status} ${JSON.stringify(json)}`);
+  return json;
+}

--- a/src/lib/paypal.ts
+++ b/src/lib/paypal.ts
@@ -1,65 +1,90 @@
-const PAYPAL_BASE =
-  process.env.PAYPAL_ENV === "live"
-    ? "https://api-m.paypal.com"
-    : "https://api-m.sandbox.paypal.com";
+import 'server-only';
 
-export async function getAccessToken() {
-  const id = process.env.PAYPAL_CLIENT_ID!;
+const ENV = process.env.PAYPAL_ENV === 'live' ? 'live' : 'sandbox';
+const BASE_URL = ENV === 'live'
+  ? 'https://api-m.paypal.com'
+  : 'https://api-m.sandbox.paypal.com';
+
+const BRAND_NAME = process.env.BRAND_NAME ?? 'Kami Kulture';
+
+type CreateOrderResponse = { id: string; status: string };
+type CaptureOrderResponse = Record<string, unknown>;
+
+async function getAccessToken(): Promise<string> {
+  const client = process.env.PAYPAL_CLIENT_ID!;
   const secret = process.env.PAYPAL_CLIENT_SECRET!;
-  const auth = Buffer.from(`${id}:${secret}`).toString("base64");
-  const res = await fetch(`${PAYPAL_BASE}/v1/oauth2/token`, {
-    method: "POST",
+  const auth = Buffer.from(`${client}:${secret}`).toString('base64');
+
+  const res = await fetch(`${BASE_URL}/v1/oauth2/token`, {
+    method: 'POST',
     headers: {
       Authorization: `Basic ${auth}`,
-      "Content-Type": "application/x-www-form-urlencoded",
+      'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: "grant_type=client_credentials",
-    cache: "no-store",
+    body: new URLSearchParams({ grant_type: 'client_credentials' }),
+    cache: 'no-store',
   });
-  if (!res.ok) throw new Error("Failed to get PayPal token");
-  return res.json() as Promise<{ access_token: string }>;
+  if (!res.ok) throw new Error(`PayPal token error: ${res.status} ${await res.text()}`);
+  const json = (await res.json()) as { access_token: string };
+  return json.access_token;
 }
 
-export async function createPaypalOrderServer(amountUSD: string) {
-  const { access_token } = await getAccessToken();
-  const res = await fetch(`${PAYPAL_BASE}/v2/checkout/orders`, {
-    method: "POST",
+// MVP product data (server-side to prevent tampering)
+const PRODUCTS = {
+  'kami-tee': { name: 'Kami Tee', price: 29.0, currency: 'USD' },
+} as const;
+
+export async function createOrder(productSlug: keyof typeof PRODUCTS, qty = 1) {
+  const product = PRODUCTS[productSlug];
+  if (!product) throw new Error('Unknown product');
+  const accessToken = await getAccessToken();
+  const amount = (product.price * qty).toFixed(2);
+
+  const res = await fetch(`${BASE_URL}/v2/checkout/orders`, {
+    method: 'POST',
     headers: {
-      Authorization: `Bearer ${access_token}`,
-      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      intent: "CAPTURE",
+      intent: 'CAPTURE',
       purchase_units: [
         {
-          amount: { currency_code: "USD", value: amountUSD },
+          amount: {
+            currency_code: product.currency,
+            value: amount,
+            breakdown: { item_total: { currency_code: product.currency, value: amount } },
+          },
+          items: [
+            {
+              name: product.name,
+              quantity: String(qty),
+              unit_amount: { currency_code: product.currency, value: product.price.toFixed(2) },
+              category: 'PHYSICAL_GOODS',
+            },
+          ],
         },
       ],
       application_context: {
-        brand_name: "Kami Kulture",
-        shipping_preference: "GET_FROM_FILE",
-        user_action: "PAY_NOW",
-        return_url: "https://kamikulture.com/thanks",
-        cancel_url: "https://kamikulture.com/cancel",
+        brand_name: BRAND_NAME,
+        user_action: 'PAY_NOW',
+        shipping_preference: 'GET_FROM_FILE',
       },
     }),
   });
-  if (!res.ok) {
-    const t = await res.text();
-    throw new Error(`Create order failed: ${t}`);
-  }
-  return res.json();
+  if (!res.ok) throw new Error(`PayPal create error: ${res.status} ${await res.text()}`);
+  return (await res.json()) as CreateOrderResponse;
 }
 
-export async function capturePaypalOrderServer(orderId: string) {
-  const { access_token } = await getAccessToken();
-  const res = await fetch(`${PAYPAL_BASE}/v2/checkout/orders/${orderId}/capture`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${access_token}` },
+export async function captureOrder(orderID: string) {
+  const accessToken = await getAccessToken();
+  const res = await fetch(`${BASE_URL}/v2/checkout/orders/${orderID}/capture`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
   });
-  if (!res.ok) {
-    const t = await res.text();
-    throw new Error(`Capture failed: ${t}`);
-  }
-  return res.json();
+  if (!res.ok) throw new Error(`PayPal capture error: ${res.status} ${await res.text()}`);
+  return (await res.json()) as CaptureOrderResponse;
 }


### PR DESCRIPTION
## 📦 Summary
Implements PayPal checkout MVP for Kami Kulture with email notifications via Resend.

## ✨ Changes
- Added `/api/paypal/create-order` and `/api/paypal/capture-order` API routes (ESLint-safe, Node runtime)
- Integrated PayPal server-side price validation (prevents client tampering)
- Wired Resend email notifications on payment capture (`orders@kamikulture.com` → `kamikulture990@gmail.com`)
- Added `PaySection` component for PayPal button
- Added `/thank-you` page to display order confirmation

## 🔑 Environment Variables
| Name                          | Example / Notes |
| ----------------------------- | --------------- |
| `NEXT_PUBLIC_PAYPAL_CLIENT_ID`| Sandbox or live client ID |
| `PAYPAL_CLIENT_ID`            | Sandbox or live client ID |
| `PAYPAL_CLIENT_SECRET`        | Sandbox or live secret |
| `PAYPAL_ENV`                  | `sandbox` or `live` |
| `RESEND_API_KEY`              | Resend API key starting with `re_` |
| `EMAIL_FROM`                  | `"Kami Kulture <orders@kamikulture.com>"` |
| `ORDER_TO_EMAIL`              | Destination email for order JSON |
| `BRAND_NAME`                  | `Kami Kulture` |

## 🧪 Testing Steps
1. **Start local dev server**
   ```bash
   npm run dev
